### PR TITLE
feat: Increase screen size and add background music

### DIFF
--- a/Connect4.py
+++ b/Connect4.py
@@ -230,9 +230,16 @@ turn = 0
 
 pygame.init()
 
+try:
+    pygame.mixer.init()
+    pygame.mixer.music.load('music.mp3')
+    pygame.mixer.music.play(-1)
+except pygame.error:
+    print("Mixer not available")
+
 turn_start_time = pygame.time.get_ticks()
 
-SQUARESIZE = 100
+SQUARESIZE = 120
 
 width = COLUMN_COUNT * SQUARESIZE
 height = (ROW_COUNT+1) * SQUARESIZE


### PR DESCRIPTION
This commit increases the screen size and adds background music to the game.

The `SQUARESIZE` constant has been increased from 100 to 120 to make the game board and the overall screen larger.

Background music has been added using `pygame.mixer`. A dummy `music.mp3` file is included, and the code is wrapped in a `try...except` block to handle environments without audio support.