### PR TITLE
fix: Handle case where AI has no valid moves

### DIFF
--- a/Connect4.py
+++ b/Connect4.py
@@ -318,7 +318,9 @@ while not game_over:
 
         col = pick_best_move(board)
 
-        if is_valid_location(board, col):
+        if col is None:
+            game_over = True
+        elif is_valid_location(board, col):
             pygame.time.wait(500)
             row = get_next_open_row(board, col)
             drop_piece(board, row, col, 1)


### PR DESCRIPTION
This commit fixes a potential crash that could occur when the game board is full and the AI has no valid moves.

The `pick_best_move` function can return `None` in this scenario. The game loop has been updated to handle this case by setting `game_over` to `True`, which prevents the game from entering an infinite loop.